### PR TITLE
Improve jobs

### DIFF
--- a/app/controllers/author_dashboards/repositories_controller.rb
+++ b/app/controllers/author_dashboards/repositories_controller.rb
@@ -30,6 +30,18 @@ module AuthorDashboards
       end
     end
 
+    # Override `destroy` action to delete local repository
+    def destroy
+      directory = Rails.root.join('repos', current_author.github_username, requested_resource.name)
+      if requested_resource.destroy
+        flash[:notice] = translate_with_resource('destroy.success')
+        FileUtils.remove_dir(directory) if Dir.exist?(directory)
+      else
+        flash[:error] = requested_resource.errors.full_messages.join('<br/>')
+      end
+      redirect_to after_resource_destroyed_path(requested_resource)
+    end
+
     # For `index` action, only show repositories belonging to the author currently authentified
     def scoped_resource
       @repositories = current_author.repositories if current_author

--- a/app/controllers/author_dashboards/repositories_controller.rb
+++ b/app/controllers/author_dashboards/repositories_controller.rb
@@ -12,12 +12,7 @@ module AuthorDashboards
       authorize_resource(resource)
 
       if resource.save
-        CreateGithubWebhookJob.perform_async(
-          resource.uuid,
-          resource.name,
-          resource.author.github_username,
-          resource.token
-        )
+        CreateGithubWebhookJob.perform_async(resource.id)
         CloneGithubRepoJob.perform_async(resource.id)
         redirect_to(
           after_resource_created_path(resource),

--- a/app/controllers/author_dashboards/repositories_controller.rb
+++ b/app/controllers/author_dashboards/repositories_controller.rb
@@ -49,6 +49,10 @@ module AuthorDashboards
             .transform_values { |v| read_param_value(v) }
     end
 
+    def after_resource_created_path(_requested_resource)
+      author_dashboards_repositories_path
+    end
+
     # See https://administrate-demo.herokuapp.com/customizing_controller_actions
     # for more information
   end

--- a/app/jobs/clone_github_repo_job.rb
+++ b/app/jobs/clone_github_repo_job.rb
@@ -9,5 +9,7 @@ class CloneGithubRepoJob
     repository.update(last_pull_at: DateTime.current)
 
     GetGithubDescriptionJob.perform_async(repository_id)
+  rescue Git::FailedError => e
+    Rails.logger.error "Failed to clone repository ##{repository.name}. Message: #{e.message}"
   end
 end

--- a/app/jobs/create_github_webhook_job.rb
+++ b/app/jobs/create_github_webhook_job.rb
@@ -13,7 +13,7 @@ class CreateGithubWebhookJob
       { url: "https://#{host_url}/webhooks/github/#{repository.uuid}", content_type: 'json', secret: webhook_secret },
       { events: ['push'], active: true }
     )
-  rescue Octokit::UnprocessableEntity => e
-    Rails.logger.error "Failed to create GitHub webhook for repository ##{repository.id}. Message: #{e.message}"
+  rescue Octokit::Unauthorized, Octokit::UnprocessableEntity => e
+    Rails.logger.error "Failed to create GitHub webhook for repository ##{repository.name}. Message: #{e.message}"
   end
 end

--- a/app/jobs/create_github_webhook_job.rb
+++ b/app/jobs/create_github_webhook_job.rb
@@ -13,6 +13,6 @@ class CreateGithubWebhookJob
       { events: ['push'], active: true }
     )
   rescue Octokit::UnprocessableEntity => e
-    p e.message
+    Rails.logger.error "Failed to create GitHub webhook for repository ##{repository.id}. Message: #{e.message}"
   end
 end

--- a/app/jobs/create_github_webhook_job.rb
+++ b/app/jobs/create_github_webhook_job.rb
@@ -1,15 +1,16 @@
 class CreateGithubWebhookJob
   include Sidekiq::Job
 
-  def perform(uuid, name, owner, token)
-    client = Octokit::Client.new(access_token: token)
+  def perform(repository_id)
+    repository = Repository.includes(:author).find(repository_id)
+    client = Octokit::Client.new(access_token: repository.token)
     host_url = Rails.application.credentials.host_url
     webhook_secret = Rails.application.credentials.webhook_secret
 
     client.create_hook(
-      "#{owner}/#{name}",
+      "#{repository.author.github_username}/#{repository.name}",
       'web',
-      { url: "https://#{host_url}/webhooks/github/#{uuid}", content_type: 'json', secret: webhook_secret },
+      { url: "https://#{host_url}/webhooks/github/#{repository.uuid}", content_type: 'json', secret: webhook_secret },
       { events: ['push'], active: true }
     )
   rescue Octokit::UnprocessableEntity => e

--- a/app/jobs/get_github_description_job.rb
+++ b/app/jobs/get_github_description_job.rb
@@ -6,5 +6,7 @@ class GetGithubDescriptionJob
     client = Octokit::Client.new(access_token: repository.token)
     response = client.repository("#{repository.author.github_username}/#{repository.name}")
     repository.update(description: response.description)
+  rescue Octokit::UnprocessableEntity => e
+    Rails.logger.error "Failed to get description for repository ##{repository.id}. Message: #{e.message}"
   end
 end

--- a/app/jobs/get_github_description_job.rb
+++ b/app/jobs/get_github_description_job.rb
@@ -6,7 +6,7 @@ class GetGithubDescriptionJob
     client = Octokit::Client.new(access_token: repository.token)
     response = client.repository("#{repository.author.github_username}/#{repository.name}")
     repository.update(description: response.description)
-  rescue Octokit::UnprocessableEntity => e
-    Rails.logger.error "Failed to get description for repository ##{repository.id}. Message: #{e.message}"
+  rescue Octokit::Unauthorized, Octokit::UnprocessableEntity => e
+    Rails.logger.error "Failed to get description for repository ##{repository.name}. Message: #{e.message}"
   end
 end

--- a/app/jobs/pull_github_repo_job.rb
+++ b/app/jobs/pull_github_repo_job.rb
@@ -8,5 +8,7 @@ class PullGithubRepoJob
     repository.update(last_pull_at: DateTime.current)
 
     GetGithubDescriptionJob.perform_async(repository_id)
+  rescue Git::FailedError => e
+    Rails.logger.error "Failed to pull repository ##{repository.name}. Message: #{e.message}"
   end
 end

--- a/app/jobs/respond_webhook_push_job.rb
+++ b/app/jobs/respond_webhook_push_job.rb
@@ -19,6 +19,8 @@ class RespondWebhookPushJob
     else
       Git.clone(repository.git_url, directory, branch: repository.branch)
     end
+  rescue Git::FailedError => e
+    Rails.logger.error "Failed to clone or pull repository ##{repository.name}. Message: #{e.message}"
   end
 
   def update_repository(repository, webhook_name, webhook_owner)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -6,6 +6,7 @@ class Repository < ApplicationRecord
 
   validates :name,
             presence: true,
+            uniqueness: true,
             format: { with: /\A[\.\w-]{0,100}\z/, message: 'must follow GitHub repository name restrictions' }
   validates :token,
             presence: true,

--- a/app/views/author_dashboards/repositories/show.html.erb
+++ b/app/views/author_dashboards/repositories/show.html.erb
@@ -46,4 +46,7 @@
           ><%= render_field attribute, page: page %></dd>
     <% end %>
   </dl>
+  <% if page.resource.last_pull_at == nil %>
+    <p>Cannot pull this repository from GitHub. Please delete this repository and verify name and token before adding a new one.</p>
+  <%end %>
 </section>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,1 @@
+:max_retries: 5

--- a/spec/jobs/create_github_webhook_spec.rb
+++ b/spec/jobs/create_github_webhook_spec.rb
@@ -4,13 +4,8 @@ RSpec.describe CreateGithubWebhookJob, type: :job do
   let(:repo) { create(:repository, :real) }
 
   it 'queues the job' do
-    CreateGithubWebhookJob.perform_async(repo.uuid, repo.name, repo.author.github_username, repo.token)
-    expect(CreateGithubWebhookJob).to have_enqueued_sidekiq_job(
-      repo.uuid,
-      repo.name,
-      repo.author.github_username,
-      repo.token
-    )
+    CreateGithubWebhookJob.perform_async(repo.id)
+    expect(CreateGithubWebhookJob).to have_enqueued_sidekiq_job(repo.id)
   end
 
   it 'executes perform' do
@@ -18,7 +13,7 @@ RSpec.describe CreateGithubWebhookJob, type: :job do
       Sidekiq::Testing.inline! do
         expect(repo.description).to be_nil
         expect(repo.last_pull_at).to be_nil
-        CreateGithubWebhookJob.perform_async(repo.uuid, repo.name, repo.author.github_username, repo.token)
+        CreateGithubWebhookJob.perform_async(repo.id)
       end
     end
   end

--- a/spec/jobs/respond_webhook_push_spec.rb
+++ b/spec/jobs/respond_webhook_push_spec.rb
@@ -23,9 +23,6 @@ RSpec.describe RespondWebhookPushJob, type: :job do
   context 'executes perform' do
     it 'when webhook_name == name && webhook_owner == repository.author.github_username' do
       Sidekiq::Testing.inline! do
-        expect(@repo.description).to be_nil
-        expect(@repo.last_pull_at).to be_nil
-
         RespondWebhookPushJob.perform_async(@repo.uuid, @repo.name, @repo.author.github_username, @repo.description)
         @repo.reload
 
@@ -35,8 +32,6 @@ RSpec.describe RespondWebhookPushJob, type: :job do
 
     it 'when webhook_name != name && webhook_owner == repository.author.github_username' do
       Sidekiq::Testing.inline! do
-        expect(@repo.last_pull_at).not_to be_nil
-
         RespondWebhookPushJob.perform_async(
           @repo.uuid, 'markdown-templates',
           @repo.author.github_username,

--- a/spec/systems/author_dashboards/repositories/delete_spec.rb
+++ b/spec/systems/author_dashboards/repositories/delete_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Delete repository as an author', type: :system do
+  before(:each) do
+    @repo = create(:repository)
+    @directory = Rails.root.join('repos', @repo.author.github_username, @repo.name)
+    FileUtils.mkdir_p(@directory)
+  end
+
+  scenario 'removes the record' do
+    before_count = Repository.all.count
+    page.set_rack_session(author_id: @repo.author.id)
+
+    visit author_dashboards_repository_path(@repo.id)
+    expect(page).to have_content('repo_name')
+
+    accept_alert do
+      click_link 'Destroy'
+    end
+
+    sleep(1)
+    expect(Repository.all.count).to eq(before_count - 1)
+  end
+
+  scenario 'removes the local directory' do
+    page.set_rack_session(author_id: @repo.author.id)
+
+    visit author_dashboards_repository_path(@repo.id)
+    expect(page).to have_content('repo_name')
+
+    accept_alert do
+      click_link 'Destroy'
+    end
+
+    sleep(1)
+    expect(Dir.exist?(@directory)).to be(false)
+  end
+end

--- a/spec/systems/author_dashboards/repositories/update_spec.rb
+++ b/spec/systems/author_dashboards/repositories/update_spec.rb
@@ -1,28 +1,12 @@
 require 'rails_helper'
-require 'support/omniauth'
 
 RSpec.describe 'Update repository as an author', type: :system do
+  before(:each) do
+    @repo = create(:repository)
+  end
+
   scenario 'to change name' do
-    # Creation of repository done here instead of using a factory
-    # because of interaction with mock auth
-    before_count = Repository.count
-
-    visit root_path
-    click_on 'Login with GitHub'
-    expect(page).to have_content('Repositories')
-
-    click_on 'New repository'
-
-    fill_in('Name', with: 'repo_name')
-    fill_in('Title', with: 'Test Repo')
-    fill_in('Token', with: 'ghp_abcde12345')
-    click_on 'Create Repository'
-
-    expect(Repository.count).to eq(before_count + 1)
-    @repo = Repository.last
-    # Creation of repository over
-
-    expect(@repo.git_url).to eq('https://ghp_abcde12345@github.com/user/repo_name.git')
+    page.set_rack_session(author_id: @repo.author.id)
 
     visit author_dashboards_repository_path(@repo.id)
     expect(page).to have_content('repo_name')
@@ -41,26 +25,7 @@ RSpec.describe 'Update repository as an author', type: :system do
   end
 
   scenario 'to change branch' do
-    # Creation of repository done here instead of using a factory
-    # because of interaction with mock auth
-    before_count = Repository.count
-
-    visit root_path
-    click_on 'Login with GitHub'
-    expect(page).to have_content('Repositories')
-
-    click_on 'New repository'
-
-    fill_in('Name', with: 'repo_name')
-    fill_in('Title', with: 'Test Repo')
-    fill_in('Token', with: 'ghp_abcde12345')
-    click_on 'Create Repository'
-
-    expect(Repository.count).to eq(before_count + 1)
-    @repo = Repository.last
-    # Creation of repository over
-
-    expect(@repo.git_url).to eq('https://ghp_abcde12345@github.com/user/repo_name.git')
+    page.set_rack_session(author_id: @repo.author.id)
 
     visit author_dashboards_repository_path(@repo.id)
     expect(page).to have_content('main')


### PR DESCRIPTION
* Set maximum number of retries for jobs to 5
* Add `rescue` blocks to all jobs, and record errors in Rails logger
* Delete local repository files if a repository is removed by an author
* Modify `CreateGithubWebhookJob` to use repository ID as argument
* Display on the Author Dashboard repository page when there are issues pulling the repository from GitHub. Since it was decided that tokens cannot be edited, the repository needs to be deleted then added back