### PR TITLE
Implement session timeout for Users and Administrators

### DIFF
--- a/app/controllers/concerns/administrator_authentication.rb
+++ b/app/controllers/concerns/administrator_authentication.rb
@@ -19,7 +19,7 @@ module AdministratorAuthentication
 
     def current_administrator
       validate_session
-      @current_administrator ||= Administrator.find(session[:administrator_id])
+      @current_administrator ||= Administrator.find(session[:administrator_id]) if session[:administrator_id]
     end
 
     def administrator_signed_in?

--- a/app/controllers/concerns/administrator_authentication.rb
+++ b/app/controllers/concerns/administrator_authentication.rb
@@ -18,11 +18,18 @@ module AdministratorAuthentication
     end
 
     def current_administrator
-      @current_administrator ||= Administrator.find(session[:administrator_id]) if session[:administrator_id]
+      validate_session
+      @current_administrator ||= Administrator.find(session[:administrator_id])
     end
 
     def administrator_signed_in?
       !!current_administrator
+    end
+
+    def validate_session
+      return if session[:administrator_expires_at].nil?
+
+      session[:administrator_id] = nil if session[:administrator_expires_at] < Time.now
     end
   end
 end

--- a/app/controllers/sessions/administrators_controller.rb
+++ b/app/controllers/sessions/administrators_controller.rb
@@ -10,6 +10,7 @@ class Sessions::AdministratorsController < ApplicationController
         redirect_to new_webauthn_authentication_path
       else
         session[:administrator_id] = administrator.id
+        session[:administrator_expires_at] = Time.now + 1.hour
         redirect_to dashboard_root_path
       end
       session[:author_id] = nil if session[:author_id]
@@ -20,6 +21,7 @@ class Sessions::AdministratorsController < ApplicationController
 
   def destroy
     session[:administrator_id] = nil
+    session[:administrator_expires_at] = nil
     redirect_to root_path
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,10 @@
 class Users::SessionsController < Devise::SessionsController
   def create
     super
-    session[:administrator_id] = nil if session[:administrator_id]
+    if session[:administrator_id]
+      session[:administrator_id] = nil
+      session[:administrator_expires_at] = nil
+    end
   end
 
   def destroy

--- a/app/controllers/webauthn/authentication_controller.rb
+++ b/app/controllers/webauthn/authentication_controller.rb
@@ -28,6 +28,7 @@ class Webauthn::AuthenticationController < ApplicationController
 
       credential.update!(sign_count: webauthn_credential.sign_count)
       session[:administrator_id] = session[:webauthn_administrator_id]
+      session[:administrator_expires_at] = Time.now + 1.hour
       session[:webauthn_administrator_id] = nil
 
       # Pass `redirect URL` to Stimulus controller. Rails `redirect_to` does not work

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,9 @@ class User < ApplicationRecord
   has_one :author, dependent: :destroy
 
   # Include default devise modules. Others available are:
-  # :lockable, :timeoutable, :trackable and :omniauthable
+  # :lockable, :rememberable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
-
-  # Override method to set remember_me == true by default
-  def remember_me
-    super.nil? ? true : super
-  end
+         :recoverable, :timeoutable, :validatable, :confirmable
 
   protected
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -167,7 +167,7 @@ Devise.setup do |config|
   # config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
-  config.expire_all_remember_me_on_sign_out = true
+  # config.expire_all_remember_me_on_sign_out = true
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
@@ -188,7 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 5.days
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/db/migrate/20230911185221_remove_remember_created_at.rb
+++ b/db/migrate/20230911185221_remove_remember_created_at.rb
@@ -1,0 +1,5 @@
+class RemoveRememberCreatedAt < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :remember_created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_171904) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_185221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,7 +74,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_171904) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
Users are logged out after 5 days of inactivity.
Administrators are logged out 1 hour after last log in. The short session time is implemented for security purposes.

Note that Authors are automatically logged out 8 hours after last log in (default GitHub app settings).