### PR TITLE
Parse questions from Markdown files

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -10,7 +10,7 @@ class CollectionsController < ApplicationController
     respond_to do |format|
       format.html do
         @front_matter = extract_front_matter(file_path)
-        parse_questions if @front_matter['questions']
+        @questions = Question.where(repository: @repository, page_path: params[:path])
         render file_path
       end
       format.any(:png, :jpg, :jpeg, :gif, :svg, :webp) do
@@ -60,12 +60,5 @@ class CollectionsController < ApplicationController
     file = "#{Rails.root}/repos/#{file_path}.md"
     loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Date])
     FrontMatterParser::Parser.parse_file(file, loader:).front_matter
-  end
-
-  def parse_questions
-    questions = @front_matter['questions']
-    questions.each do |tag, body|
-      Question.find_or_create_by(repository: @repository, tag:, body:, page_path: params[:path])
-    end
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,5 +1,5 @@
 class CollectionsController < ApplicationController
-  before_action :modify_view_path
+  before_action :modify_view_path, :require_user_or_admin_authentication
   layout 'collections'
 
   def show
@@ -29,6 +29,11 @@ class CollectionsController < ApplicationController
   end
 
   private
+  def require_user_or_admin_authentication
+    return if administrator_signed_in? || user_signed_in?
+
+    redirect_to root_path, alert: 'Please log in to continue.'
+  end
 
   def modify_view_path
     prepend_view_path "#{Rails.root}/repos"

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -29,6 +29,6 @@ class RepositoriesController < ApplicationController
     repository = Repository.find(params[:id])
     return if administrator_signed_in? || current_author.id == repository.author_id
 
-    redirect_to root_path, alert: 'Please sign as author or administrator'
+    redirect_to root_path, alert: 'Please log in as an author or administrator.'
   end
 end

--- a/app/jobs/clone_github_repo_job.rb
+++ b/app/jobs/clone_github_repo_job.rb
@@ -11,6 +11,7 @@ class CloneGithubRepoJob
     build.logs.create(content: 'Repository successfully cloned.', step:)
 
     GetGithubDescriptionJob.perform_async(repository_id, build_id)
+    ParseQuestionsJob.perform_async(repository_id, build_id)
     CreateRepoIndexJob.perform_async(repository_id, build_id)
   rescue Git::FailedError => e
     build.logs.create(content: "Failed to clone repository. Message: #{e.message}", failure: true, step:)

--- a/app/jobs/create_repo_index_job.rb
+++ b/app/jobs/create_repo_index_job.rb
@@ -5,6 +5,7 @@ class CreateRepoIndexJob
     repository, directory = RepositoryDirectory.define(repository_id)
     build = Build.find(build_id)
     step = step_for_action(build.action)
+
     if index_file_exists?(directory)
       build.logs.create(content: 'index.md file exists for this repository.', step:)
     else
@@ -13,16 +14,18 @@ class CreateRepoIndexJob
     end
   end
 
+  private
+
   def step_for_action(action)
     case action
     when 'create'
-      5
+      6
     when 'webhook_push'
-      4
+      5
     when 'update'
-      3
+      4
     when 'rebuild'
-      3
+      4
     end
   end
 

--- a/app/jobs/parse_questions_job.rb
+++ b/app/jobs/parse_questions_job.rb
@@ -1,16 +1,32 @@
 class ParseQuestionsJob
   include Sidekiq::Job
 
-  def perform(repository_id)
+  def perform(repository_id, build_id)
     repository, directory = RepositoryDirectory.define(repository_id)
+    build = Build.find(build_id)
+    step = step_for_action(build.action)
 
     markdown_files = list_markdown_absolute_path_and_page_name(directory)
     markdown_files.each do |absolute_path, page_name|
       parse_questions(repository, absolute_path, page_name)
     end
+    build.logs.create(content: 'Questions successfully parsed.', step:)
   end
 
   private
+
+  def step_for_action(action)
+    case action
+    when 'create'
+      5
+    when 'webhook_push'
+      4
+    when 'update'
+      3
+    when 'rebuild'
+      3
+    end
+  end
 
   def list_markdown_absolute_path_and_page_name(directory)
     absolute_paths = Dir.glob("#{directory}/**/*.md")

--- a/app/jobs/parse_questions_job.rb
+++ b/app/jobs/parse_questions_job.rb
@@ -1,0 +1,38 @@
+class ParseQuestionsJob
+  include Sidekiq::Job
+
+  def perform(repository_id)
+    repository, directory = RepositoryDirectory.define(repository_id)
+
+    markdown_files = list_markdown_absolute_path_and_page_name(directory)
+    markdown_files.each do |absolute_path, page_name|
+      parse_questions(repository, absolute_path, page_name)
+    end
+  end
+
+  private
+
+  def list_markdown_absolute_path_and_page_name(directory)
+    absolute_paths = Dir.glob("#{directory}/**/*.md")
+    absolute_paths.map! do |path|
+      [path, path.remove("#{directory}/", '.md')]
+    end
+  end
+
+  def parse_questions(repository, absolute_path, page_name)
+    front_matter = extract_front_matter(absolute_path)
+    front_matter['questions']&.each do |tag, body|
+      Question.find_or_create_by(
+        repository:,
+        tag:,
+        body:,
+        page_path: page_name
+      )
+    end
+  end
+
+  def extract_front_matter(file_path)
+    loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Date])
+    FrontMatterParser::Parser.parse_file(file_path, loader:).front_matter
+  end
+end

--- a/app/jobs/pull_github_repo_job.rb
+++ b/app/jobs/pull_github_repo_job.rb
@@ -11,8 +11,9 @@ class PullGithubRepoJob
     build.logs.create(content: 'Repository successfully pulled.', step:)
 
     GetGithubDescriptionJob.perform_async(repository_id, build_id)
+    ParseQuestionsJob.perform_async(repository.id, build.id)
     if response == 'Already up to date'
-      build.logs.create(content: 'index.md file exists for this repository.', step: step + 1)
+      build.logs.create(content: 'index.md file exists for this repository.', step: 4)
     else
       CreateRepoIndexJob.perform_async(repository.id, build.id)
     end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -26,10 +26,10 @@ class Build < ApplicationRecord
   private
 
   MAX_LOG_STEPS = {
-    create: 5,
-    update: 3,
-    rebuild: 3,
-    webhook_push: 4
+    create: 6,
+    update: 4,
+    rebuild: 4,
+    webhook_push: 5
   }.freeze
 
   # `latest_log` is passed as an argument when using the `after_add` callback

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,7 @@
+class Question < ApplicationRecord
+  belongs_to :repository
+
+  validates :tag, presence: true
+  validates :page_path, presence: true
+  validates :body, presence: true
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,6 +1,7 @@
 class Repository < ApplicationRecord
   belongs_to :author
   has_many :builds, dependent: :destroy
+  has_many :questions, dependent: :destroy
 
   before_create :set_branch, :generate_uuid
   before_save :set_git_url

--- a/app/views/dashboard/application/_navigation.html.erb
+++ b/app/views/dashboard/application/_navigation.html.erb
@@ -1,9 +1,9 @@
-<%# Override default view to add information about current administrator, sign out button and edit MFA credentials button %>
+<%# Override default view to add information about current administrator, logout button and edit MFA credentials button %>
 
 <nav class="navigation">
   <h3>Admin: <%= current_administrator.name %></h3>
   <br />
-  <%= button_to 'Sign out', sessions_administrator_path, method: :delete, data: { turbo: false }, class: "button button--nav"  %>
+  <%= button_to 'Logout', sessions_administrator_path, method: :delete, data: { turbo: false }, class: "button button--nav"  %>
 
   <%= link_to 'Edit MFA credentials', webauthn_credentials_path, class: "button button--alt button--nav" %>
   <br />

--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -16,6 +16,20 @@
 
     <%= yield %>
 
+
+    <% if @front_matter['questions'] %>
+      <h2 id="questions">
+        <a href="#questions" class="collections__anchor-link">Questions</a>
+        <i class="fa-solid fa-link" aria-hidden="true"></i>
+      </h2>
+
+      <ul>
+      <% @front_matter['questions'].each do |question| %>
+        <li id="<%= question[0] %>"><%= question[1] %></li>
+      <% end %>
+      </ul>
+    <% end %>
+
     <hr />
     <%= link_to 'View book',
                 index_path(request.path),

--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -17,15 +17,15 @@
     <%= yield %>
 
 
-    <% if @front_matter['questions'] %>
+    <% if @questions && @questions.any? %>
       <h2 id="questions">
         <a href="#questions" class="collections__anchor-link">Questions</a>
         <i class="fa-solid fa-link" aria-hidden="true"></i>
       </h2>
 
       <ul>
-      <% @front_matter['questions'].each do |question| %>
-        <li id="<%= question[0] %>"><%= question[1] %></li>
+      <% @questions.each do |question| %>
+        <li id="<%= question.tag %>"><%= question.body %></li>
       <% end %>
       </ul>
     <% end %>

--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -23,11 +23,11 @@
         <i class="fa-solid fa-link" aria-hidden="true"></i>
       </h2>
 
-      <ul>
+      <ol>
       <% @questions.each do |question| %>
         <li id="<%= question.tag %>"><%= simple_format(question.body) %></li>
       <% end %>
-      </ul>
+      </ol>
     <% end %>
 
     <hr />

--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -25,7 +25,7 @@
 
       <ul>
       <% @questions.each do |question| %>
-        <li id="<%= question.tag %>"><%= question.body %></li>
+        <li id="<%= question.tag %>"><%= simple_format(question.body) %></li>
       <% end %>
       </ul>
     <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -8,7 +8,7 @@
       <%= link_to 'Settings', settings_root_path %>
       <%= button_to 'Logout', destroy_user_session_path, method: :delete, data: { turbo: false } %>
     <% elsif current_administrator %>
-      <%= button_to 'Sign out', sessions_administrator_path, method: :delete, data: { turbo: false } %>
+      <%= button_to 'Logout', sessions_administrator_path, method: :delete, data: { turbo: false } %>
     <% else %>
       <%= link_to 'Login', new_user_session_path %>
     <% end %>

--- a/db/migrate/20231002145653_create_questions.rb
+++ b/db/migrate/20231002145653_create_questions.rb
@@ -1,0 +1,12 @@
+class CreateQuestions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :questions do |t|
+      t.references :repository, foreign_key: true
+      t.string :tag
+      t.string :page_path
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_26_183907) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_02_145653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -52,6 +52,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_183907) do
     t.boolean "failure", default: false
     t.integer "step"
     t.index ["build_id"], name: "index_logs_on_build_id"
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.bigint "repository_id"
+    t.string "tag"
+    t.string "page_path"
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_id"], name: "index_questions_on_repository_id"
   end
 
   create_table "repositories", force: :cascade do |t|
@@ -101,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_183907) do
   add_foreign_key "authors", "users"
   add_foreign_key "builds", "repositories"
   add_foreign_key "logs", "builds"
+  add_foreign_key "questions", "repositories"
   add_foreign_key "repositories", "authors"
   add_foreign_key "webauthn_credentials", "administrators"
 end

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :question do
+    body { 'Is this is real question?' }
+    tag { 'first' }
+    page_path { 'article.md' }
+    association :repository
+  end
+end

--- a/spec/jobs/parse_questions_spec.rb
+++ b/spec/jobs/parse_questions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ParseQuestionsJob, type: :job do
   before(:all) do
     @repo = create(:repository, last_pull_at: DateTime.current)
+    @build = create(:build, repository: @repo)
     directory = Rails.root.join('repos', @repo.author.github_username, @repo.name)
     folder_directory = directory.join('Folder')
     FileUtils.mkdir_p(folder_directory)
@@ -42,14 +43,14 @@ RSpec.describe ParseQuestionsJob, type: :job do
   end
 
   it 'queues the job' do
-    ParseQuestionsJob.perform_async(@repo.id)
-    expect(ParseQuestionsJob).to have_enqueued_sidekiq_job(@repo.id)
+    ParseQuestionsJob.perform_async(@repo.id, @build.id)
+    expect(ParseQuestionsJob).to have_enqueued_sidekiq_job(@repo.id, @build.id)
   end
 
   context 'when executing the job' do
     before(:all) do
       Sidekiq::Testing.inline! do
-        ParseQuestionsJob.perform_async(@repo.id)
+        ParseQuestionsJob.perform_async(@repo.id, @build.id)
       end
     end
 

--- a/spec/jobs/parse_questions_spec.rb
+++ b/spec/jobs/parse_questions_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe ParseQuestionsJob, type: :job do
+  before(:all) do
+    @repo = create(:repository, last_pull_at: DateTime.current)
+    directory = Rails.root.join('repos', @repo.author.github_username, @repo.name)
+    folder_directory = directory.join('Folder')
+    FileUtils.mkdir_p(folder_directory)
+
+    first_filepath = File.join(directory, 'article_one.md')
+    article_one_content = <<~ARTICLE
+      ---
+      title: "First Article"
+      date: "2023-10-02"
+      author: "The Author"
+      illustrator: "The Illustrator"
+      questions:
+        - ["one", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus."]
+        - ["two", "Habitant morbi tristique senectus et."]
+      ---
+
+      Article one content
+    ARTICLE
+
+    File.open(first_filepath, 'w') { |f| f.write(article_one_content) }
+
+    second_filepath = File.join(directory, 'Folder', 'article_two.md')
+    article_two_content = <<~ARTICLE
+      ---
+      title: "Second Article"
+      date: "2023-10-03"
+      author: "The Author"
+      illustrator: "The Illustrator"
+      questions:
+        - ["three", "Et ligula ullamcorper malesuada proin libero. Ullamcorper sit amet risus nullam."]
+        - ["four", "Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus."]
+      ---
+
+      Article two content
+    ARTICLE
+    File.open(second_filepath, 'w') { |f| f.write(article_two_content) }
+  end
+
+  it 'queues the job' do
+    ParseQuestionsJob.perform_async(@repo.id)
+    expect(ParseQuestionsJob).to have_enqueued_sidekiq_job(@repo.id)
+  end
+
+  context 'when executing the job' do
+    before(:all) do
+      Sidekiq::Testing.inline! do
+        ParseQuestionsJob.perform_async(@repo.id)
+      end
+    end
+
+    it 'creates questions associated with the first article' do
+      questions = Question.where(page_path: 'article_one')
+      expect(questions.count).to eq(2)
+    end
+
+    it 'creates questions associated with the second article' do
+      questions = Question.where(page_path: 'Folder/article_two')
+      expect(questions.count).to eq(2)
+    end
+  end
+
+  after(:all) do
+    parent_directory = Rails.root.join('repos', @repo.author.github_username)
+    directory = parent_directory.join(@repo.name)
+    FileUtils.remove_dir(directory)
+    FileUtils.remove_dir(parent_directory)
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Question, type: :model do
+  describe '#valid?' do
+    subject { build(:question) }
+
+    it 'returns false when not associated with a Repository' do
+      subject.repository = nil
+      expect(subject).to_not be_valid
+    end
+
+    it 'returns false when body is nil' do
+      subject.body = nil
+      expect(subject).to_not be_valid
+    end
+
+    it 'returns false when tag is nil' do
+      subject.tag = nil
+      expect(subject).to_not be_valid
+    end
+
+    it 'returns false when page_path is nil' do
+      subject.page_path = nil
+      expect(subject).to_not be_valid
+    end
+
+    it 'returns true when body, tag and page_path are set and when associated with a Repository' do
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/requests/webhooks/github_controller_spec.rb
+++ b/spec/requests/webhooks/github_controller_spec.rb
@@ -70,7 +70,11 @@ describe Webhooks::GithubController do
           end
 
           scenario 'with fourth log' do
-            expect(@build.logs.fourth.content).to eq('index.md file exists for this repository.')
+            expect(@build.logs.fourth.content).to eq('Questions successfully parsed.')
+          end
+
+          scenario 'with fifth log' do
+            expect(@build.logs.fifth.content).to eq('index.md file exists for this repository.')
           end
 
           scenario "with status 'Complete'" do

--- a/spec/systems/collections/index_spec.rb
+++ b/spec/systems/collections/index_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe 'Collections#index', type: :system do
   end
 
   context 'repository is set to banned = false' do
+    before do
+      sign_in @repo.author.user
+    end
+
     scenario 'displays Markdown text in HTML' do
       visit '/collections/jp524/markdown-templates/pages/index'
 
@@ -35,6 +39,7 @@ RSpec.describe 'Collections#index', type: :system do
   context 'repository is set to banned = true' do
     before do
       @repo.update(banned: true)
+      sign_in @repo.author.user
     end
 
     scenario 'displays an error page' do

--- a/spec/systems/collections/show_spec.rb
+++ b/spec/systems/collections/show_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Collections#show', type: :system do
       VCR.use_cassette('clone_github_repo_for_collections') do
         CloneGithubRepoJob.perform_async(@repo.id, build.id)
       end
+      ParseQuestionsJob.perform_async(@repo.id, build.id)
     end
   end
 
@@ -35,6 +36,30 @@ RSpec.describe 'Collections#show', type: :system do
       visit '/collections/jp524/markdown-templates/pages/chapter-1/chapter-1-article-1'
       expect(page).to have_content('Non anser honore ornique')
       expect(page).to have_content('Written by The Author on 2023-12-31')
+    end
+
+    context 'when page has questions in front-matter' do
+      scenario 'displays the questions associated with an article' do
+        visit '/collections/jp524/markdown-templates/pages/chapter-1/chapter-1-article-1'
+
+        expect(page).to have_content('First question in article one?')
+        expect(page).to have_content('Second question in article one?')
+      end
+
+      scenario 'does not display questions associated with other articles' do
+        visit '/collections/jp524/markdown-templates/pages/chapter-1/chapter-1-article-1'
+
+        expect(page).to_not have_content('First question in article two?')
+        expect(page).to_not have_content('Second question in article two?')
+      end
+    end
+
+    context 'when page does not have questions in front-matter' do
+      scenario 'does not show the Questions header' do
+        visit '/collections/jp524/markdown-templates/pages/chapter-2/chapter-2-article-1'
+
+        expect(page).to_not have_content('Questions')
+      end
     end
   end
 

--- a/spec/systems/collections/show_spec.rb
+++ b/spec/systems/collections/show_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe 'Collections#show', type: :system do
   end
 
   context 'repository is set to banned = false' do
+    before do
+      sign_in @repo.author.user
+    end
+
     scenario 'displays Markdown text in HTML' do
       visit '/collections/jp524/markdown-templates/pages/chapter-1/chapter-1-article-1'
 
@@ -66,6 +70,7 @@ RSpec.describe 'Collections#show', type: :system do
   context 'repository is set to banned = true' do
     before do
       @repo.update(banned: true)
+      sign_in @repo.author.user
     end
 
     scenario 'displays an error page' do

--- a/spec/systems/repositories/update_spec.rb
+++ b/spec/systems/repositories/update_spec.rb
@@ -43,8 +43,12 @@ RSpec.describe 'Repositories#update', type: :system do
         expect(@rebuild_build.logs.second.content).to eq('Repository description successfully updated from GitHub.')
       end
 
-      scenario 'creates the third log' do
-        expect(@rebuild_build.logs.third.content).to eq('index.md file exists for this repository.')
+      scenario 'with the third log' do
+        expect(@rebuild_build.logs.third.content).to eq('Questions successfully parsed.')
+      end
+
+      scenario 'creates the fourth log' do
+        expect(@rebuild_build.logs.fourth.content).to eq('index.md file exists for this repository.')
       end
 
       scenario "sets Build status to 'Complete'" do

--- a/spec/systems/sessions/administrators/destroy_spec.rb
+++ b/spec/systems/sessions/administrators/destroy_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe 'Sessions::Administrators#destroy', type: :system do
     )
   end
 
-  scenario 'sign out' do
+  scenario 'logout' do
     page.set_rack_session(administrator_id: @admin.id)
 
     visit dashboard_root_path
     expect(page).to have_content("Admin: #{@admin.name}")
-    click_on 'Sign out'
+    click_on 'Logout'
 
     expect(page).to have_current_path(root_path)
   end

--- a/spec/systems/settings/authors/repositories/create_spec.rb
+++ b/spec/systems/settings/authors/repositories/create_spec.rb
@@ -109,8 +109,12 @@ RSpec.describe 'Settings::Authors::Repositories#create', type: :system do
       expect(@build.logs.fourth.content).to eq('Repository description successfully updated from GitHub.')
     end
 
-    scenario 'creates the fifth log' do
-      expect(@build.logs.fifth.content).to eq('index.md file successfully generated.')
+    scenario 'with fifth log' do
+      expect(@build.logs.fifth.content).to eq('Questions successfully parsed.')
+    end
+
+    scenario 'creates the sixth log' do
+      expect(@build.logs[5].content).to eq('index.md file successfully generated.')
     end
 
     scenario "sets Build status to 'Complete'" do

--- a/spec/systems/settings/authors/repositories/update_spec.rb
+++ b/spec/systems/settings/authors/repositories/update_spec.rb
@@ -83,8 +83,12 @@ RSpec.describe 'Settings::Authors::Repositories#update', type: :system do
         expect(@update_build.logs.second.content).to eq('Repository description successfully updated from GitHub.')
       end
 
-      scenario 'creates the third log' do
-        expect(@update_build.logs.third.content).to eq('index.md file exists for this repository.')
+      scenario 'with the third log' do
+        expect(@update_build.logs.third.content).to eq('Questions successfully parsed.')
+      end
+
+      scenario 'creates the fourth log' do
+        expect(@update_build.logs.fourth.content).to eq('index.md file exists for this repository.')
       end
 
       scenario "sets Build status to 'Complete'" do


### PR DESCRIPTION
Authors can add questions to their articles by using the following syntax in the front-matter of their Markdown files:

```yaml
---
...
questions:
  - ['question tag', 'question text']
  - ['question tag', 'question text']
---
```

When a repository is pulled or cloned as part of the Build process, its content is parsed to identify questions within each Markdown files. The questions are saved in the database if they don't exit.

### Other improvements
* User or administrator authentication is required to access articles through the `CollectionsController`
* Mentions of `sign out` was replaced by `logout` for consistency