### PR TITLE
Add code syntax highlight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ gem 'administrate'
 gem 'aasm'
 gem 'after_commit_everywhere', '~> 1.0'
 
+# Code syntax highlighter
+gem 'rouge'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    rouge (4.1.3)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -426,6 +427,7 @@ DEPENDENCIES
   rails (~> 7.0.8)
   redcarpet
   redis (~> 4.0)
+  rouge
   rspec-rails
   rspec-sidekiq
   selenium-webdriver

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
+@import "rouge.css";
 @import "milligram";
 
 @import "utilities/sr-only";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,6 @@
-@import "rouge.css";
+// Rouge style sheet imported separately since there are issued with
+// the `dartsass-rails` gem and `erb` files
+
 @import "milligram";
 
 @import "utilities/sr-only";

--- a/app/assets/stylesheets/rouge.css.erb
+++ b/app/assets/stylesheets/rouge.css.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::Base16.mode(:light).render(scope: '.highlight') %>

--- a/app/assets/stylesheets/rouge.css.erb
+++ b/app/assets/stylesheets/rouge.css.erb
@@ -1,1 +1,1 @@
-<%= Rouge::Themes::Base16.mode(:light).render(scope: '.highlight') %>
+<%= Rouge::Themes::Github.render(scope: '.highlight') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%# Importing Rouge stylesheet here since it cannot be imported in `application.scss` due
+    to issues with `dartsass-rails` gem and `erb` files %>
+    <%= stylesheet_link_tag 'rouge' %>
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Figtree&family=Istok+Web">
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,4 +9,4 @@ Rails.application.config.assets.version = "1.0"
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[rouge.css]

--- a/config/initializers/custom_render.rb
+++ b/config/initializers/custom_render.rb
@@ -1,5 +1,9 @@
 # Custom renderer that sets a custom class for code blocks
+require 'rouge/plugins/redcarpet'
+
 class CustomRender < Redcarpet::Render::HTML
+  include Rouge::Plugins::Redcarpet
+
   def paragraph(text)
     process_custom_tags(text.strip)
   end

--- a/vendor/assets/stylesheets/_Code.sass
+++ b/vendor/assets/stylesheets/_Code.sass
@@ -3,7 +3,6 @@
 // ––––––––––––––––––––––––––––––––––––––––––––––––––
 
 code
-  background: $color-background
   border-radius: .4rem
   font-size: 90%
   margin: 0 .2rem
@@ -11,7 +10,6 @@ code
   white-space: nowrap
 
 pre
-  background: $color-background
   border-left: .3rem solid $color-tertiary
   overflow-y: hidden
 


### PR DESCRIPTION
Modify Redcarpet renderer to include syntax highlights for code blocks.