### PR TITLE
Improve questions parsing

### DIFF
--- a/app/jobs/parse_questions_job.rb
+++ b/app/jobs/parse_questions_job.rb
@@ -26,7 +26,10 @@ class ParseQuestionsJob
 
   def parse_questions(repository, batch_code, absolute_path, page_name)
     front_matter = extract_front_matter(absolute_path)
-    front_matter['questions']&.each do |tag, body|
+    return if front_matter['questions'].nil?
+
+    questions = front_matter['questions'].inject(:merge!)
+    questions.each do |tag, body|
       question = Question.find_by(repository:, tag:, page_path: page_name)
       if question.nil?
         Question.create(repository:, tag:, page_path: page_name, body:, batch_code:)

--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -23,11 +23,13 @@
         <i class="fa-solid fa-link" aria-hidden="true"></i>
       </h2>
 
-      <ol>
-      <% @questions.each do |question| %>
-        <li id="<%= question.tag %>"><%= simple_format(question.body) %></li>
+      <% @questions.each_with_index do |question, index| %>
+        <div class="question">
+          <h3><%= "Question #{index + 1}" %></h3>
+
+          <%= simple_format(question.body) %>
+        </div>
       <% end %>
-      </ol>
     <% end %>
 
     <hr />

--- a/spec/fixtures/jobs/parse_questions/first_round/Folder/article_two.md
+++ b/spec/fixtures/jobs/parse_questions/first_round/Folder/article_two.md
@@ -4,8 +4,8 @@ date: "2023-10-03"
 author: "The Author"
 illustrator: "The Illustrator"
 questions:
-  - ["three", "Et ligula ullamcorper malesuada proin libero. Ullamcorper sit amet risus nullam."]
-  - ["four", "Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus."]
+  - three: Et ligula ullamcorper malesuada proin libero. Ullamcorper sit amet risus nullam.
+  - four: Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus.
 ---
 
 Article two content

--- a/spec/fixtures/jobs/parse_questions/first_round/article_one.md
+++ b/spec/fixtures/jobs/parse_questions/first_round/article_one.md
@@ -4,8 +4,8 @@ date: "2023-10-02"
 author: "The Author"
 illustrator: "The Illustrator"
 questions:
-  - ["one", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus."]
-  - ["two", "Habitant morbi tristique senectus et."]
+  - one: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus.
+  - two: Habitant morbi tristique senectus et.
 ---
 
 Article one content

--- a/spec/fixtures/jobs/parse_questions/second_round/article_one.md
+++ b/spec/fixtures/jobs/parse_questions/second_round/article_one.md
@@ -4,7 +4,7 @@ date: "2023-10-02"
 author: "The Author"
 illustrator: "The Illustrator"
 questions:
-  - ["two", "Habitant morbi tristique senectus et."]
+  - two: Habitant morbi tristique senectus et.
 ---
 
 Article one content

--- a/spec/fixtures/jobs/parse_questions/third_round/article_one.md
+++ b/spec/fixtures/jobs/parse_questions/third_round/article_one.md
@@ -4,8 +4,8 @@ date: "2023-10-02"
 author: "The Author"
 illustrator: "The Illustrator"
 questions:
-  - ["one", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus."]
-  - ["two", "Habitant morbi tristique senectus et."]
+  - one: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus.
+  - two: Habitant morbi tristique senectus et.
 ---
 
 Article one content

--- a/spec/fixtures/systems/collections/chapter-1/chapter-1-article-1.md
+++ b/spec/fixtures/systems/collections/chapter-1/chapter-1-article-1.md
@@ -4,8 +4,8 @@ date: 2023-12-31
 author: The Author
 keywords: [one, two]
 questions:
-  - ['one', 'First question in article one?']
-  - ['two', 'Second question in article one?']
+  - one: First question in article one?
+  - two: Second question in article one?
 ---
 
 ![Ruby on Rails logo](./figures/Ruby_On_Rails_Logo.png)

--- a/spec/fixtures/systems/collections/chapter-1/chapter-1-article-2.md
+++ b/spec/fixtures/systems/collections/chapter-1/chapter-1-article-2.md
@@ -4,8 +4,8 @@ date: 2023-12-31
 author: The Author
 keywords: [one, two]
 questions:
-  - ['one', 'First question in article two?']
-  - ['two', 'Second question in article two?']
+  - one: First question in article two?
+  - two: Second question in article two?
 ---
 
 ## Amplectitur atque mutabile


### PR DESCRIPTION
Implement a different syntax for the YAML front-matter in order to preserve new lines and increase readability.
New format for questions is:
```yaml
- questions:
   - plant: |
       You're creating an automatic plant watering system. The plant should be watered if:

       - The soil is dry.
       - It's daytime.

       Write pseudocode to determine whether the plant should be watered or not.
   - software: Can you give examples of software applications you use on a daily basis?
```

Short questions can fit on the same line as the tag. For multi-line questions, the block style indicator `|` is added on the first line and the following lines must be indented per [YAML specifications](https://yaml.org/spec/1.2.2/#23-scalars).