### PR TITLE
Modify RemoveRepoJob to call destroy action in controller

### DIFF
--- a/app/controllers/settings/authors/repositories_controller.rb
+++ b/app/controllers/settings/authors/repositories_controller.rb
@@ -51,7 +51,12 @@ module Settings
       end
 
       def destroy
-        RemoveRepoJob.perform_async(@repository.id)
+        github_username = @repository.author.github_username
+        name = @repository.name
+        directory = Rails.root.join('repos', github_username, name)
+
+        RemoveRepoJob.perform_async(github_username, name, @repository.hook_id, @repository.token, directory.to_s)
+        @repository.destroy
         redirect_to settings_author_repositories_path, notice: 'Repository was successfully deleted.'
       end
 

--- a/app/jobs/remove_repo_job.rb
+++ b/app/jobs/remove_repo_job.rb
@@ -1,16 +1,14 @@
 class RemoveRepoJob
   include Sidekiq::Job
 
-  def perform(repository_id)
-    repository, directory = RepositoryDirectory.define(repository_id)
-    remove_webhook(repository)
+  def perform(github_username, name, hook_id, token, directory)
+    remove_webhook(github_username, name, hook_id, token)
     delete_local_files(directory)
-    repository.destroy
   end
 
-  def remove_webhook(repository)
-    client = Octokit::Client.new(access_token: repository.token)
-    client.remove_hook("#{repository.author.github_username}/#{repository.name}", repository.hook_id)
+  def remove_webhook(github_username, name, hook_id, token)
+    client = Octokit::Client.new(access_token: token)
+    client.remove_hook("#{github_username}/#{name}", hook_id)
   end
 
   def delete_local_files(directory)

--- a/spec/jobs/remove_repo_job_spec.rb
+++ b/spec/jobs/remove_repo_job_spec.rb
@@ -3,30 +3,32 @@ require 'rails_helper'
 RSpec.describe RemoveRepoJob, type: :job do
   let(:repo) { create(:repository, :real, hook_id: 436760769) }
   let(:client) { Octokit::Client.new(access_token: repo.token) }
+  let(:github_username) { repo.author.github_username }
+  let(:directory) { Rails.root.join('repos', github_username, repo.name).to_s }
 
   it 'queues the job' do
-    RemoveRepoJob.perform_async(repo.id)
-    expect(RemoveRepoJob).to have_enqueued_sidekiq_job(repo.id)
+    RemoveRepoJob.perform_async(github_username, repo.name, repo.hook_id, repo.token, directory)
+    expect(RemoveRepoJob).to have_enqueued_sidekiq_job(github_username, repo.name, repo.hook_id, repo.token, directory)
   end
 
   context 'when executing perform' do
     before do
       VCR.use_cassette('remove_repo') do
         Sidekiq::Testing.inline! do
-          RemoveRepoJob.perform_async(repo.id)
+          RemoveRepoJob.perform_async(github_username, repo.name, repo.hook_id, repo.token, directory)
         end
       end
     end
 
     it 'removes the webhook' do
       VCR.use_cassette('get_repo_webhooks') do
-        get_repo_hooks = client.hooks("#{repo.author.github_username}/#{repo.name}")
+        get_repo_hooks = client.hooks("#{github_username}/#{repo.name}")
         expect(get_repo_hooks).to eq([])
       end
     end
 
-    it 'removes the record from the database' do
-      expect(Repository.exists?(repo.id)).to be false
+    it 'does not removes the record from the database' do
+      expect(Repository.exists?(repo.id)).to be true
     end
   end
 end


### PR DESCRIPTION
The previous behaviour called the `destroy` action inside `RemoveRepoJob`. After the repository was deleted and the request redirected to repositories#index page, the repository was still present.

By calling `destroy` in the controller, the repository is immediately removed from the repositories#index page. `RemoveRepoJob` can perform the removal of the directory and webhook later.