### PR TITLE
Lint database migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,12 +59,6 @@ Rails/ThreeStateBooleanColumn:
     - db/migrate/20230905171904_add_action_to_builds_and_failure_to_logs.rb
     - db/migrate/20231005175303_add_hidden_and_batch_code_to_questions.rb
 
-Rails/UniqueValidationWithoutIndex:
-  Exclude:
-    - app/models/administrator.rb
-    - app/models/author.rb
-    - app/models/repository.rb
-
 RSpec/BeforeAfterAll:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem 'after_commit_everywhere', '~> 1.0'
 # Code syntax highlighter
 gem 'rouge'
 
+# Catch unsafe database migrations
+gem 'strong_migrations'
+
 group :development, :test do
   gem 'brakeman'
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,8 @@ GEM
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.0.8)
+    strong_migrations (1.6.3)
+      activerecord (>= 5.2)
     thor (1.2.2)
     tilt (2.3.0)
     timeout (0.4.0)
@@ -515,6 +517,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   stimulus-rails
+  strong_migrations
   turbo-rails
   tzinfo-data
   vcr

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -8,8 +8,8 @@ class Repository < ApplicationRecord
 
   validates :name,
             presence: true,
-            uniqueness: true,
             format: { with: /\A[.\w-]{0,100}\z/, message: 'must follow GitHub repository name restrictions' }
+  validates :name, uniqueness: { scope: :author_id }
   validates :token,
             presence: true,
             format: { with: /\A(github_pat|ghp)\w+\z/, message: 'must start with "github_pat" or "ghp"' }

--- a/db/migrate/20231106204257_add_index_for_uniqueness.rb
+++ b/db/migrate/20231106204257_add_index_for_uniqueness.rb
@@ -1,0 +1,9 @@
+class AddIndexForUniqueness < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :administrators, :name, unique: true, algorithm: :concurrently
+    add_index :authors, :github_uid, unique: true, algorithm: :concurrently
+    add_index :authors, :github_username, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20231107154115_add_index_repository_name_author.rb
+++ b/db/migrate/20231107154115_add_index_repository_name_author.rb
@@ -1,0 +1,7 @@
+class AddIndexRepositoryNameAuthor < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :repositories, %i[name author_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_06_204257) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_07_154115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_06_204257) do
     t.boolean "banned", default: false
     t.integer "hook_id"
     t.index ["author_id"], name: "index_repositories_on_author_id"
+    t.index ["name", "author_id"], name: "index_repositories_on_name_and_author_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_17_200835) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_06_204257) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_17_200835) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "webauthn_id"
+    t.index ["name"], name: "index_administrators_on_name", unique: true
   end
 
   create_table "answers", force: :cascade do |t|
@@ -42,6 +43,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_17_200835) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.bigint "user_id"
+    t.index ["github_uid"], name: "index_authors_on_github_uid", unique: true
+    t.index ["github_username"], name: "index_authors_on_github_username", unique: true
     t.index ["user_id"], name: "index_authors_on_user_id", unique: true
   end
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe Repository do
       repo = build(:repository)
       expect(repo.valid?).to be true
     end
+
+    it 'returns false when a repository with the same name exists for a given author' do
+      first_repository = create(:repository)
+      author = first_repository.author
+      second_repo = build(:repository, author:)
+      expect(second_repo.valid?).to be false
+    end
+
+    it 'returns true when a repository with the same name exists for another author' do
+      create(:repository)
+      second_author = create(:author, :real)
+      second_repo = build(:repository, author: second_author)
+      expect(second_repo.valid?).to be true
+    end
   end
 
   describe '#set_git_url' do


### PR DESCRIPTION
- Ensure future migrations will be checked using `strong_migrations` gem
- Fix Rubocop warning for unique index
- Fix validation of uniqueness for Repository.name. Repositories can have the same name as long as they belong to different authors