### PR TITLE
Add rescue for Octokit::Forbidden in background jobs

### DIFF
--- a/app/jobs/create_github_webhook_job.rb
+++ b/app/jobs/create_github_webhook_job.rb
@@ -10,7 +10,7 @@ class CreateGithubWebhookJob
 
     build.logs.create(content: 'GitHub webhook successfully created. Now testing...')
     build.finished_creating_webhook
-  rescue Octokit::Unauthorized, Octokit::UnprocessableEntity => e
+  rescue Octokit::Unauthorized, Octokit::UnprocessableEntity, Octokit::Forbidden => e
     build.logs.create(content: "Failed to create GitHub webhook. Message: #{e.message}", failure: true)
   end
 

--- a/app/jobs/get_github_description_job.rb
+++ b/app/jobs/get_github_description_job.rb
@@ -10,7 +10,7 @@ class GetGithubDescriptionJob
 
     build.logs.create(content: 'Repository description successfully updated from GitHub.')
     build.finished_getting_repo_description
-  rescue Octokit::Unauthorized, Octokit::UnprocessableEntity => e
+  rescue Octokit::Unauthorized, Octokit::UnprocessableEntity, Octokit::Forbidden => e
     build.logs.create(content: "Failed to get description from GitHub. Message: #{e.message}", failure: true)
   end
 


### PR DESCRIPTION
This rescues 403 Forbidden errors received by Octokit. This can happen in instances when a personal access token does not have access to a specific repository.