### PR TITLE
Prioritize rendering of Markdown files over HTML pages

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -68,13 +68,8 @@ class CollectionsController < ApplicationController
     send_file Rails.root.join("repos/#{file_path}.#{request.format.to_sym}").to_s
   end
 
-  def extract_front_matter_from_relative_path(file_path)
-    absolute_path = Rails.root.join("repos/#{file_path}.md").to_s
-    helpers.extract_front_matter(absolute_path)
-  end
-
   def extract_markdown_file(file_path)
-    @front_matter = extract_front_matter_from_relative_path(file_path)
-    @markdown_content = Rails.root.join("repos/#{file_path}.md").read
+    absolute_path = Rails.root.join("repos/#{file_path}.md").to_s
+    @front_matter, @markdown_content = helpers.split_markdown(absolute_path)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -6,7 +6,7 @@ class CollectionsController < ApplicationController
     file_path = "#{params[:owner]}/#{params[:name]}/index"
     render_not_found and return unless valid_render?(file_path, params[:owner], params[:name])
 
-    @front_matter = extract_front_matter_from_relative_path(file_path)
+    extract_markdown_file(file_path)
     render file_path
   end
 
@@ -33,8 +33,7 @@ class CollectionsController < ApplicationController
   def show_actions(file_path)
     respond_to do |format|
       format.html do
-        @front_matter = extract_front_matter_from_relative_path(file_path)
-        @markdown_content = Rails.root.join("repos/#{file_path}.md").read
+        extract_markdown_file(file_path)
         @questions = Question.where(repository: @repository, page_path: params[:path])
         render file_path
       end
@@ -72,5 +71,10 @@ class CollectionsController < ApplicationController
   def extract_front_matter_from_relative_path(file_path)
     absolute_path = Rails.root.join("repos/#{file_path}.md").to_s
     helpers.extract_front_matter(absolute_path)
+  end
+
+  def extract_markdown_file(file_path)
+    @front_matter = extract_front_matter_from_relative_path(file_path)
+    @markdown_content = Rails.root.join("repos/#{file_path}.md").read
   end
 end

--- a/app/helpers/extract_front_matter_helper.rb
+++ b/app/helpers/extract_front_matter_helper.rb
@@ -1,6 +1,0 @@
-module ExtractFrontMatterHelper
-  def extract_front_matter(absolute_path)
-    loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Date])
-    FrontMatterParser::Parser.parse_file(absolute_path, loader:).front_matter
-  end
-end

--- a/app/helpers/render_markdown_helper.rb
+++ b/app/helpers/render_markdown_helper.rb
@@ -1,0 +1,17 @@
+module RenderMarkdownHelper
+  def render_markdown(markdown_content)
+    return if markdown_content.nil?
+
+    extensions = {
+      fenced_code_blocks: true,
+      disable_indented_code_blocks: true
+    }
+
+    render_options = {
+      escape_html: true,
+      with_toc_data: true
+    }
+
+    Redcarpet::Markdown.new(CustomRender.new(render_options), extensions).render(markdown_content)
+  end
+end

--- a/app/helpers/split_markdown_helper.rb
+++ b/app/helpers/split_markdown_helper.rb
@@ -1,0 +1,7 @@
+module SplitMarkdownHelper
+  def split_markdown(absolute_path)
+    loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Date])
+    parsed = FrontMatterParser::Parser.parse_file(absolute_path, loader:)
+    [parsed.front_matter, parsed.content]
+  end
+end

--- a/app/jobs/parse_questions_job.rb
+++ b/app/jobs/parse_questions_job.rb
@@ -1,6 +1,6 @@
 class ParseQuestionsJob
   include Sidekiq::Job
-  include ExtractFrontMatterHelper
+  include SplitMarkdownHelper
 
   def perform(build_id)
     build = Build.find(build_id)
@@ -31,7 +31,7 @@ class ParseQuestionsJob
   end
 
   def extract_questions(absolute_path)
-    front_matter = extract_front_matter(absolute_path)
+    front_matter, _markdown_content = split_markdown(absolute_path)
     questions_array = front_matter['questions']
 
     questions_array&.inject(:merge!)

--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -20,7 +20,7 @@
              data-export-marp-markdown-value="<%= @markdown_content %>">
         </div>
       <% else %>
-        <%= yield %>
+        <%= render_markdown(@markdown_content).html_safe %>
         <% if @questions && @questions.any? %>
           <h2 id="questions" class="collections__anchor-link">
             <a href="#questions" class="collections__anchor-link__text">Questions</a>

--- a/config/initializers/markdown_handler.rb
+++ b/config/initializers/markdown_handler.rb
@@ -1,29 +1,8 @@
 # Custom handler to render Markdown files in HTML
 module MarkdownHandler
-  # erb template handler to allow support of embedded erb inside Markdown files
-  def self.erb
-    @erb ||= ActionView::Template.registered_template_handler(:erb)
-  end
-
-  def self.call(template, source)
-    erb_source = "#{erb.call(template, parsed_content(source))}.to_s"
-    extensions = {
-      fenced_code_blocks: true,
-      disable_indented_code_blocks: true
-    }
-
-    render_options = {
-      escape_html: true,
-      with_toc_data: true
-    }
-
-    "Redcarpet::Markdown.new(CustomRender.new(#{render_options}), #{extensions}).render(begin;#{erb_source};end)"
-  end
-
-  def self.parsed_content(source)
-    loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Date])
-    parsed = FrontMatterParser::Parser.new(:md, loader:).call(source)
-    parsed.content
+  # Rendering is performed by `collections.html.erb`
+  def self.call(_template, _source)
+    ""
   end
 end
 

--- a/config/initializers/markdown_handler.rb
+++ b/config/initializers/markdown_handler.rb
@@ -1,6 +1,6 @@
 # Custom handler to render Markdown files in HTML
 module MarkdownHandler
-  # Rendering is performed by `collections.html.erb`
+  # Rendering is performed by `layouts/collections`
   def self.call(_template, _source)
     ""
   end

--- a/spec/fixtures/systems/collections/chapter-2/chapter-2-article-2.html
+++ b/spec/fixtures/systems/collections/chapter-2/chapter-2-article-2.html
@@ -1,0 +1,1 @@
+<h1>Content from HTML file</h1>

--- a/spec/fixtures/systems/collections/index.html
+++ b/spec/fixtures/systems/collections/index.html
@@ -1,0 +1,1 @@
+<h1>Content from HTML file</h1>

--- a/spec/systems/collections/index_spec.rb
+++ b/spec/systems/collections/index_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe 'Collections#index', type: :system do
       expect(page).to have_content('Course Name')
       expect(page).to have_content('Written by The Author on 2023-12-31')
     end
+
+    it 'does not render content from an HTML file with the same name' do
+      visit '/collections/user/markdown-templates/pages/index'
+      expect(page).not_to have_content('Content from HTML file')
+    end
   end
 
   context 'when repository is set to banned = true' do

--- a/spec/systems/collections/show_spec.rb
+++ b/spec/systems/collections/show_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe 'Collections#show', type: :system do
       expect(page).to have_content('Written by The Author on 2023-12-31')
     end
 
+    it 'does not render content from an HTML file with the same name' do
+      visit '/collections/user/markdown-templates/pages/chapter-2/chapter-2-article-2'
+      expect(page).not_to have_content('Content from HTML file')
+    end
+
     context 'when page has questions in front-matter' do
       it 'displays the questions associated with an article' do
         visit '/collections/user/markdown-templates/pages/chapter-1/chapter-1-article-1'


### PR DESCRIPTION
If a repository contains two files with identical names but different extensions (i.e. `article.md` and `article.html.erb`), the rendering of the Markdown file must be prioritized over the rendering of the HTML file.

This is done for security concerns, as the content of Markdown files is sanitized before being displayed.