### PR TITLE
Modify Repository visibility based on Build status

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -51,7 +51,7 @@ class CollectionsController < ApplicationController
     author_id = Author.find_by(github_username: owner).id
     @repository = Repository.find_by(author_id:, name:)
 
-    @repository.banned == false
+    @repository.visible?
   end
 
   def valid_render?(file_path, owner, name)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -26,6 +26,10 @@ class Repository < ApplicationRecord
     builds.last&.status
   end
 
+  def visible?
+    banned == false && last_build_status == 'Complete'
+  end
+
   private
 
   def set_git_url

--- a/app/views/settings/authors/repositories/index.html.erb
+++ b/app/views/settings/authors/repositories/index.html.erb
@@ -32,7 +32,9 @@
           <%= link_to 'View book',
                       "/collections/#{repository.author.github_username}/#{repository.name}/pages/index",
                       target: :_blank,
-                      class: 'button button-small button-tertiary' %>
+                      class: 'button button-small button-tertiary',
+                      disabled: !repository.visible?,
+                      title: "#{repository.visible? ? '' : 'This repository is disabled' }" %>
           <%= link_to 'Edit', edit_settings_author_repository_path(repository.id), class: 'button button-small' %>
           <%= link_to 'Show builds', settings_author_repository_builds_path(repository.id), class: 'button button-small' %>
         </div>

--- a/vendor/assets/stylesheets/_Button.sass
+++ b/vendor/assets/stylesheets/_Button.sass
@@ -33,7 +33,7 @@ input[type='submit']
     text-decoration: none
 
   &[disabled]
-    cursor: default
+    cursor: not-allowed
     opacity: .5
 
     &:focus,
@@ -74,6 +74,7 @@ input[type='submit']
       &:focus,
       &:hover
         color: $color-primary
+        pointer-events: none
 
   &.button-tertiary
     background-color: $color-tertiary


### PR DESCRIPTION
A repository is only visible if its last build has a status of "Complete". This is to prevent repositories with builds "In progress" or "Failed" from being displayed.