### PR TITLE
Configure Action Mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,9 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem 'spring'
+
+  # Preview email in browser instead of sending it
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,10 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -504,6 +508,7 @@ DEPENDENCIES
   git
   importmap-rails
   jbuilder
+  letter_opener
   octokit
   omniauth-github
   omniauth-rails_csrf_protection

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,10 @@ class User < ApplicationRecord
   def password_required?
     confirmed? ? super : false
   end
+
+  # Override method to send e-mail using background job
+  def send_devise_notification(notification, *)
+    message = devise_mailer.send(notification, self, *)
+    message.deliver_later
+  end
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,3 +3,5 @@
 <p>You can confirm your account email through the link below:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+
+<p><b>KnewHub</b></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -5,3 +5,5 @@
 <% else %>
   <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
 <% end %>
+
+<p><b>KnewHub</b></p>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,5 @@
 <p>Hello <%= @resource.email %>!</p>
 
 <p>We're contacting you to notify you that your password has been changed.</p>
+
+<p><b>KnewHub</b></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -6,3 +6,5 @@
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>
+
+<p><b>KnewHub</b></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,9 @@ module Knewhub
 
     # Prevent creation of `div class="field_with_errors"` wrapper upon invalid form submission
     config.action_view.field_error_proc = ->(html_tag, _instance) { html_tag.html_safe }
+
+    # Configure queue adapter to use with Action Mailer (relying on Active Job)
+    # Other jobs are done with native Sidekiq
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,13 +39,17 @@ Rails.application.configure do
   # URL used in links from Devise emails
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
-  # Receive emails in MailDev at http://localhost:1080
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: 'maildev',
-    port: 1025,
-    enable_starttls_auto: false
-  }
+  # Emails will be available in a new browser tab 
+  config.action_mailer.delivery_method = :letter_opener
+
+  # Receive emails in MailDev at http://localhost:1080 when using Docker
+  # config.action_mailer.delivery_method = :smtp 
+  # config.action_mailer.smtp_settings = {
+  #   address: 'maildev',
+  #   port: 1025,
+  #   enable_starttls_auto: false
+  # }
+
   config.action_mailer.perform_deliveries = true
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,6 +72,17 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "knewhub_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: URI(ENV.fetch('WEB_URL')).hostname }
+  config.action_mailer.smtp_settings = {
+    address:         'smtp-relay.brevo.com',
+    port:            587,
+    user_name:       ENV.fetch('BREVO_USERNAME'),
+    password:        ENV.fetch('BREVO_PASSWORD'),
+    authentication:  'plain',
+    enable_starttls: true,
+    open_timeout:    5,
+    read_timeout:    5 }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
- In development environment, revert back to using `letter-opener` gem to open received emails in a new browser window
- In production environment, add credentials and configuration to use SMTP
- Modify Devise mailer method to use a background job in order to send e-mails