### PR TITLE
Fix redirect after User account deletion

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,15 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
+    # Override method to redirect to root_path inside Turbo Frame.
+    # Otherwise, "content missing" is displayed inside the Turbo Frame
+    def destroy
+      resource.destroy
+      Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+      set_flash_message! :notice, :destroyed
+      yield resource if block_given?
+      redirect_after_destroy
+    end
+
     protected
 
     # Override method to render `edit_user_registration` when using Turbo Stream
@@ -11,6 +21,15 @@ module Users
         end
       else
         new_session_path(resource_name)
+      end
+    end
+
+    private
+
+    def redirect_after_destroy
+      respond_to do |format|
+        format.html { redirect_to root_path }
+        format.turbo_stream { render turbo_stream: turbo_stream.action(:redirect, root_path) }
       end
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails"
 import "controllers"
 
 import {far} from "@fortawesome/free-regular-svg-icons"
@@ -12,3 +12,7 @@ library.add(far, fas, fab)
 import "timezone"
 import { register } from "swiper/element/bundle";
 register();
+
+Turbo.StreamActions.redirect = function () {
+  Turbo.visit(this.target)
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -46,6 +46,6 @@
     <h3>Cancel my account</h3>
 
     <p> If you are an author, this will also delete your author profile and any repositories you may have.</p>
-    <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %>
+    <%= button_to "Cancel my account", registration_path(resource_name), data: { turbo_confirm: "Are you sure?" }, method: :delete %>
   </div>
 <% end %>


### PR DESCRIPTION
The redirect wasn't working because the User account deletion takes place inside a Turbo Frame.
There was also a second confirmation pop-up that was not required.