### PR TITLE
Debug 'installation created' webhook event

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -33,6 +33,7 @@ module Webhooks
 
     def handle_installation_event
       if github_params[:action] == 'created'
+        sleep(2) # Introduce delay to ensure Author is created before installation event is processed
         create_installation_event
       elsif github_params[:action] == 'deleted'
         delete_installation_event

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -24,6 +24,8 @@ module Webhooks
     private
 
     def verify_event
+      head :bad_request and return if request.headers['X-Hub-Signature-256'].nil?
+
       secret = Rails.application.credentials.webhook_secret
       signature = "sha256=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), secret, request.raw_post)}"
       return if ActiveSupport::SecurityUtils.secure_compare(signature, request.headers['X-Hub-Signature-256'])

--- a/spec/cassettes/get_installation_access_token.yml
+++ b/spec/cassettes/get_installation_access_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.github.com/app/installations/47537695/access_tokens
+    uri: https://api.github.com/app/installations/47766910/access_tokens
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/factories/github_installation.rb
+++ b/spec/factories/github_installation.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     trait :real do
       uid { '85654561' }
       username { 'jp524' }
-      installation_id { '47537695' }
+      installation_id { '47766910' }
       association :author, :real
     end
 

--- a/spec/requests/webhooks/github_controller_push_spec.rb
+++ b/spec/requests/webhooks/github_controller_push_spec.rb
@@ -28,7 +28,7 @@ describe Webhooks::GithubController do
               name: 'jp524'
             }
           },
-          installation: { id: 47_537_695 }
+          installation: { id: 47_766_910 }
         }
 
         secret = Rails.application.credentials.webhook_secret
@@ -99,7 +99,7 @@ describe Webhooks::GithubController do
               name: 'jp524'
             }
           },
-          installation: { id: 47_537_695 }
+          installation: { id: 47_766_910 }
         }
 
         new_params = { repository: 'modified params render signature invalid' }


### PR DESCRIPTION
When a user authorizes the GitHub App, an Author record is created and a webhook event 'installation created' is received. This leads to a race condition where the Author is sometimes created after the webhook is received.

The issue is fixed by introducing a two second delay when an 'installation created' webhook event is received.

The `verify_event` method is also updated to ensure that webhooks received contain the header `X-Hub-Signature-256`.