### PR TITLE
Update deployment guide with modified VM firewall rules

### DIFF
--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -64,7 +64,7 @@
         * Boot disk type: `Balanced persistent disk`
         * Size: `10` GB
     * Service account: `compute-engine` service account created earlier
-    * Firewall: `Allow HTTPS traffic`
+    * Firewall: `Allow HTTP traffic` & `Allow HTTPS traffic`
     * Advanced options -> Networking -> Network interfaces -> Edit network interface: click on `default` network and select option `knewhub-vm` under "External IPv4 address"
 4. Point the domain `knewhub.com` to the static external IP address of the VM
 


### PR DESCRIPTION
Allowing HTTP traffic is required for browsers to correctly resolve `knewhub.com` into `https://knewhub.com`.
Caddy server then ensures that HTTPS is used by default.